### PR TITLE
Rely on cron for second-stage workflow timing

### DIFF
--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -25,8 +25,8 @@ jobs:
       - name: Update flake inputs
         run: nix flake update
 
-      - name: Check flake
-        run: nix flake check
+      - name: Run lightweight CI check
+        run: nix eval .#homeConfigurations.personal-linux.activationPackage.drvPath --raw
 
       - name: Create Pull Request
         id: create-pr

--- a/.github/workflows/update-mynixvim.yml
+++ b/.github/workflows/update-mynixvim.yml
@@ -45,10 +45,6 @@ jobs:
           branch: update-mynixvim-input
           delete-branch: true
 
-      - name: Wait before merge
-        if: steps.create-pr.outputs.pull-request-number
-        run: sleep 1800
-
       - name: Merge PR immediately
         if: steps.create-pr.outputs.pull-request-number
         run: |

--- a/.github/workflows/update-mynixvim.yml
+++ b/.github/workflows/update-mynixvim.yml
@@ -2,7 +2,7 @@ name: Update Mynixvim Input
 
 on:
   schedule:
-    - cron: '30 9 * * 1'  # Every Monday at 9:30 AM UTC
+    - cron: '0 10 * * 1'  # Every Monday at 10 AM UTC
   workflow_dispatch: # Allow manual triggering
 
 permissions:
@@ -25,8 +25,8 @@ jobs:
       - name: Update mynixvim input
         run: nix flake update mynixvim
 
-      - name: Check flake
-        run: nix flake check
+      - name: Run lightweight CI check
+        run: nix eval .#homeConfigurations.personal-linux.activationPackage.drvPath --raw
 
       - name: Create Pull Request
         id: create-pr
@@ -44,6 +44,10 @@ jobs:
             Please review the changes before merging.
           branch: update-mynixvim-input
           delete-branch: true
+
+      - name: Wait before merge
+        if: steps.create-pr.outputs.pull-request-number
+        run: sleep 1800
 
       - name: Merge PR immediately
         if: steps.create-pr.outputs.pull-request-number


### PR DESCRIPTION
Remove the fixed sleep and rely on the staggered cron schedule for second-stage workflow ordering.