### PR TITLE
Fix home workflow eval path and rely on cron

### DIFF
--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -26,7 +26,7 @@ jobs:
         run: nix flake update
 
       - name: Run lightweight CI check
-        run: nix eval .#homeConfigurations.personal-linux.activationPackage.drvPath --raw
+        run: nix eval .#homeConfigurations.mebaran.activationPackage.drvPath --raw
 
       - name: Create Pull Request
         id: create-pr

--- a/.github/workflows/update-mynixvim.yml
+++ b/.github/workflows/update-mynixvim.yml
@@ -26,7 +26,7 @@ jobs:
         run: nix flake update mynixvim
 
       - name: Run lightweight CI check
-        run: nix eval .#homeConfigurations.personal-linux.activationPackage.drvPath --raw
+        run: nix eval .#homeConfigurations.mebaran.activationPackage.drvPath --raw
 
       - name: Create Pull Request
         id: create-pr

--- a/.github/workflows/update-mynixvim.yml
+++ b/.github/workflows/update-mynixvim.yml
@@ -45,10 +45,6 @@ jobs:
           branch: update-mynixvim-input
           delete-branch: true
 
-      - name: Wait before merge
-        if: steps.create-pr.outputs.pull-request-number
-        run: sleep 1800
-
       - name: Merge PR immediately
         if: steps.create-pr.outputs.pull-request-number
         run: |


### PR DESCRIPTION
Use the exported home configuration username key in the lightweight eval checks and remove the fixed sleep from the second-stage workflow.