### PR TITLE
Merge nixvim into home flake

### DIFF
--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Run lightweight CI check
         run: nix eval .#homeConfigurations.mebaran.activationPackage.drvPath --raw
 
+      - name: Run lightweight Nixvim check
+        run: nix eval .#packages.x86_64-linux.nvim.drvPath --raw
+
       - name: Create Pull Request
         id: create-pr
         uses: peter-evans/create-pull-request@v8
@@ -41,7 +44,7 @@ jobs:
             Changes:
             - Updated nixpkgs to latest unstable
             - Updated home-manager to latest version
-            - Updated mynixvim to latest version
+            - Updated nixvim to latest version
             
             Please review the changes before merging.
           branch: update-flake-inputs

--- a/flake.lock
+++ b/flake.lock
@@ -144,46 +144,6 @@
     },
     "flake-parts": {
       "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib"
-      },
-      "locked": {
-        "lastModified": 1778716662,
-        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
-      }
-    },
-    "flake-parts_2": {
-      "inputs": {
-        "nixpkgs-lib": [
-          "mynixvim",
-          "nixvim",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1778716662,
-        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
-      }
-    },
-    "flake-parts_3": {
-      "inputs": {
         "nixpkgs-lib": [
           "nix-ai-tools",
           "nixpkgs"
@@ -203,7 +163,28 @@
         "type": "github"
       }
     },
-    "flake-parts_4": {
+    "flake-parts_2": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nixvim",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778716662,
+        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_3": {
       "inputs": {
         "nixpkgs-lib": [
           "stylix",
@@ -277,31 +258,6 @@
         "type": "github"
       }
     },
-    "mynixvim": {
-      "inputs": {
-        "flake-parts": "flake-parts",
-        "nix-ai-tools": [
-          "nix-ai-tools"
-        ],
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "nixvim": "nixvim"
-      },
-      "locked": {
-        "lastModified": 1779712767,
-        "narHash": "sha256-V5reRN9Sv3fERgAf/EQ+uKozpC25oSCOq4esswWc5FQ=",
-        "owner": "mebaran",
-        "repo": "mynixvim",
-        "rev": "b6cd456b45896fce3a269d9f95094f2d6dc9860f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "mebaran",
-        "repo": "mynixvim",
-        "type": "github"
-      }
-    },
     "mytools": {
       "inputs": {
         "nixpkgs": [
@@ -329,11 +285,11 @@
       "inputs": {
         "blueprint": "blueprint",
         "bun2nix": "bun2nix",
-        "flake-parts": "flake-parts_3",
+        "flake-parts": "flake-parts",
         "nixpkgs": [
           "nixpkgs"
         ],
-        "systems": "systems_2",
+        "systems": "systems",
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
@@ -366,36 +322,20 @@
         "type": "github"
       }
     },
-    "nixpkgs-lib": {
-      "locked": {
-        "lastModified": 1777168982,
-        "narHash": "sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ=",
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "rev": "f5901329dade4a6ea039af1433fb087bd9c1fe14",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "type": "github"
-      }
-    },
     "nixvim": {
       "inputs": {
         "flake-parts": "flake-parts_2",
         "nixpkgs": [
-          "mynixvim",
           "nixpkgs"
         ],
-        "systems": "systems"
+        "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1779683452,
-        "narHash": "sha256-Ksx8jghpDBCPDiTaTyGhYUXG1BUwqPjf5pajl0q0cqA=",
+        "lastModified": 1779816597,
+        "narHash": "sha256-Kgod3gZlhSp6WozZ2pFaclXbWpjs6kQLAtldoxb85Lc=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "afec1bae0e6f7983a5c03ec559f7ed2ec0e714a9",
+        "rev": "297f9341476ba7f821a42d7a2805e206ef8c6ef8",
         "type": "github"
       },
       "original": {
@@ -482,10 +422,10 @@
     "root": {
       "inputs": {
         "home-manager": "home-manager",
-        "mynixvim": "mynixvim",
         "mytools": "mytools",
         "nix-ai-tools": "nix-ai-tools",
         "nixpkgs": "nixpkgs",
+        "nixvim": "nixvim",
         "stylix": "stylix"
       }
     },
@@ -496,7 +436,7 @@
         "base16-helix": "base16-helix",
         "base16-vim": "base16-vim",
         "firefox-gnome-theme": "firefox-gnome-theme",
-        "flake-parts": "flake-parts_4",
+        "flake-parts": "flake-parts_3",
         "gnome-shell": "gnome-shell",
         "nixpkgs": [
           "nixpkgs"

--- a/flake.nix
+++ b/flake.nix
@@ -25,10 +25,9 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
-    mynixvim = {
-      url = "github:mebaran/mynixvim";
+    nixvim = {
+      url = "github:nix-community/nixvim";
       inputs.nixpkgs.follows = "nixpkgs";
-      inputs.nix-ai-tools.follows = "nix-ai-tools";
     };
 
     mytools = {
@@ -38,16 +37,63 @@
   };
 
   outputs = {
+    self,
     nixpkgs,
     home-manager,
-    mynixvim,
+    nixvim,
     stylix,
     nix-ai-tools,
     mytools,
     ...
   }: let
+    lib = nixpkgs.lib;
+    nvimSystems = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "aarch64-darwin"
+    ];
+    nvimLangs = {
+      nixlang = import ./nixvim/lang/nixlang.nix;
+      python = import ./nixvim/lang/python.nix;
+      web = import ./nixvim/lang/web.nix;
+      sql = import ./nixvim/lang/sql.nix;
+      golang = import ./nixvim/lang/golang.nix;
+      json = import ./nixvim/lang/json.nix;
+      markdown = import ./nixvim/lang/markdown.nix;
+    };
+    nvimOutputsFor = system: let
+      pkgs = import nixpkgs {
+        inherit system;
+      };
+      nixvimLib = nixvim.lib.${system};
+      nixvim' = nixvim.legacyPackages.${system};
+      nixvimModule = {
+        inherit pkgs;
+        module = import ./nixvim/config;
+        extraSpecialArgs = {
+          aitools = nix-ai-tools.packages.${system};
+        };
+      };
+      baseNvim = nixvim'.makeNixvimWithModule nixvimModule;
+      allLangNvim = lib.foldl (n: l: n.extend l) baseNvim (lib.attrValues nvimLangs);
+      nvimPackages =
+        {
+          nvim = allLangNvim;
+          nvim-all = allLangNvim;
+        }
+        // lib.mapAttrs' (name: value:
+          lib.nameValuePair "nvim-${name}" (baseNvim.extend value))
+        nvimLangs;
+    in {
+      packages.${system} = nvimPackages;
+      checks.${system}.nvim = nixvimLib.check.mkTestDerivationFromNixvimModule nixvimModule;
+      devShells.${system} = lib.mapAttrs' (name: value:
+        lib.nameValuePair name (pkgs.mkShell {buildInputs = [value];}))
+      nvimPackages;
+    };
     cliModules = [
       stylix.homeModules.stylix
+      nixvim.homeModules.nixvim
       ./home.nix
     ];
     desktopModules =
@@ -55,7 +101,6 @@
       ++ [
         ./desktop
       ];
-    lib = nixpkgs.lib;
     homes = {
       personal-linux = rec {
         system = "x86_64-linux";
@@ -91,19 +136,20 @@
       homeConfigurations.${username} = home-manager.lib.homeManagerConfiguration {
         inherit pkgs modules;
         extraSpecialArgs = {
-          inherit mynixvim system username homeDirectory;
+          inherit system username homeDirectory;
           aitools = nix-ai-tools.packages.${system};
           mytools = mytools.packages.${system};
         };
       };
       devShells.${system}.default = pkgs.mkShell {
         buildInputs = [
-          mynixvim.packages.${system}.nixlang
+          self.packages.${system}.nvim-nixlang
           pkgs.alejandra
         ];
       };
     };
     homeConfigs = lib.mapAttrs (k: v: homeMaker v) homes;
+    nvimConfigs = lib.genAttrs nvimSystems nvimOutputsFor;
   in
-    lib.foldl lib.recursiveUpdate {} (lib.attrValues homeConfigs);
+    lib.foldl lib.recursiveUpdate {} (lib.attrValues (homeConfigs // nvimConfigs));
 }

--- a/home.nix
+++ b/home.nix
@@ -1,8 +1,7 @@
 {
+  aitools,
   config,
   pkgs,
-  mynixvim,
-  system,
   username,
   homeDirectory,
   ...
@@ -12,6 +11,8 @@ in {
   stylix.enable = true;
   stylix.base16Scheme = "${pkgs.base16-schemes}/share/themes/tomorrow-night.yaml";
 
+  gtk.gtk4.theme = config.gtk.theme;
+
   programs.home-manager.enable = true;
 
   home = {
@@ -20,12 +21,22 @@ in {
 
   home.stateVersion = "24.11";
 
-  home.packages = [
-    (mynixvim.packages.${system}.nixlang.extend colors)
-  ];
-
-  home.sessionVariables = {
-    EDITOR = "nvim";
+  programs.nixvim = {
+    enable = true;
+    defaultEditor = true;
+    _module.args.aitools = aitools;
+    nixpkgs.useGlobalPackages = true;
+    imports = [
+      ./nixvim/config
+      ./nixvim/lang/nixlang.nix
+      ./nixvim/lang/python.nix
+      ./nixvim/lang/web.nix
+      ./nixvim/lang/sql.nix
+      ./nixvim/lang/golang.nix
+      ./nixvim/lang/json.nix
+      ./nixvim/lang/markdown.nix
+      colors
+    ];
   };
 
   imports = [

--- a/nixvim/config/colorscheme.nix
+++ b/nixvim/config/colorscheme.nix
@@ -1,0 +1,3 @@
+{
+  colorscheme = "minispring";
+}

--- a/nixvim/config/default.nix
+++ b/nixvim/config/default.nix
@@ -1,0 +1,32 @@
+{pkgs, ...}: {
+  # Import all your configuration modules here
+  imports = [./plugins ./editor.nix ./keymaps.nix ./colorscheme.nix];
+
+  extraPackages = with pkgs; [
+    fd
+    git
+    lazygit
+    ripgrep
+  ];
+
+  performance = {
+    byteCompileLua = {
+      enable = true;
+      configs = true;
+      initLua = true;
+      nvimRuntime = true;
+      plugins = true;
+    };
+    combinePlugins = {
+      enable = true;
+      pathsToLink = ["/template"];
+      standalonePlugins = [
+        "friendly-snippets"
+        "blink.cmp"
+        "snacks.nvim"
+      ];
+    };
+  };
+
+  vimAlias = true;
+}

--- a/nixvim/config/editor.nix
+++ b/nixvim/config/editor.nix
@@ -1,0 +1,78 @@
+let
+  indent = 4;
+in {
+  globals = {
+    mapleader = " ";
+  };
+  opts = {
+    # misc;
+    backspace = ["eol" "start" "indent"];
+    encoding = "utf-8";
+    matchpairs = ["(:)" "{:}" "[:]" "<:>"];
+    syntax = "enable";
+    listchars = "tab:▸ ";
+    exrc = true;
+
+    # indentation;
+    autoindent = true;
+    expandtab = true;
+    shiftwidth = indent;
+    smartindent = true;
+    softtabstop = indent;
+    tabstop = indent;
+
+    # search;
+    hlsearch = true;
+    ignorecase = true;
+    smartcase = true;
+    wildmenu = true;
+
+    # ui;
+    number = true;
+    rnu = true;
+    scrolloff = 20;
+    showmode = false;
+    sidescrolloff = 3;
+    signcolumn = "yes";
+
+    # backups;
+    backup = false;
+    swapfile = false;
+    writebackup = false;
+    updatetime = 250;
+
+    # folding config
+    foldlevel = 99;
+    foldlevelstart = 99;
+    foldenable = true;
+  };
+
+  diagnostic.settings = {
+    virtual_text = false;
+    underline = true;
+    severity_sort = true;
+  };
+
+  # Term improvements
+  autoCmd = [
+    {
+      event = ["TermOpen" "TermEnter"];
+      callback.__raw = ''
+        function(event)
+            vim.cmd("setlocal nonumber")
+            vim.cmd("setlocal norelativenumber")
+            vim.cmd("setlocal signcolumn=yes:1")
+            -- vim.cmd('startinsert!')
+            vim.cmd("set cmdheight=1")
+            -- vim.bo[event.buf].buflisted = false
+            vim.keymap.set("n", "q", "<cmd>close<cr>", { buffer = event.buf, silent = true })
+        end
+      '';
+    }
+    {
+      event = "WinEnter";
+      pattern = "term://*";
+      command = "startinsert!";
+    }
+  ];
+}

--- a/nixvim/config/keymaps.nix
+++ b/nixvim/config/keymaps.nix
@@ -1,0 +1,238 @@
+{
+  keymaps = [
+    # Quickfix and Location list
+    {
+      mode = "n";
+      key = "<leader>xl";
+      action = "<cmd>lopen<cr>";
+      options.desc = "Open Location List";
+    }
+    {
+      mode = "n";
+      key = "<leader>xq";
+      action = "<cmd>copen<cr>";
+      options.desc = "Open Quickfix List";
+    }
+    {
+      mode = "n";
+      key = "<leader>xc";
+      action = "<cmd>cclose<cr>";
+      options.desc = "Close Quickfix / Location Buffer";
+    }
+    {
+      mode = "n";
+      key = "<leader>xb";
+      action = "<C-w>b<C-w>c";
+      options.desc = "Close bottom window";
+    }
+
+    # Window resize
+    {
+      mode = "n";
+      key = "<C-Left>";
+      action = "<Cmd>vertical resize -2<CR>";
+      options.desc = "Decrease window width";
+    }
+    {
+      mode = "n";
+      key = "<C-Down>";
+      action = "<Cmd>resize -2<CR>";
+      options.desc = "Decrease window height";
+    }
+    {
+      mode = "n";
+      key = "<C-Up>";
+      action = "<Cmd>resize +2<CR>";
+      options.desc = "Increase window height";
+    }
+    {
+      mode = "n";
+      key = "<C-Right>";
+      action = "<Cmd>vertical resize +2<CR>";
+      options.desc = "Increase window width";
+    }
+
+    # Terminal
+    {
+      mode = "t";
+      key = "<C-W>";
+      action = ''<C-\><C-N><C-w>'';
+      options.desc = "Focus other window";
+    }
+    {
+      mode = "t";
+      key = "<C-x>";
+      action = ''<C-\><C-n>'';
+      options.desc = "Quick access to normal mode";
+    }
+    {
+      mode = "n";
+      key = "<leader>tv";
+      action.__raw = ''
+        function()
+          Snacks.terminal('zsh', {win={position="right", width=0.5}})
+        end
+      '';
+      options.desc = "Split terminal vertically";
+    }
+    {
+      mode = "n";
+      key = "<leader>tx";
+      action.__raw = "function() Snacks.terminal() end";
+      options.desc = "Split terminal horizontally";
+    }
+    {
+      mode = "n";
+      key = "<leader>lg";
+      action.__raw = "function() Snacks.lazygit() end";
+      options.desc = "Pop up Lazygit";
+    }
+
+    # Diagnostics
+    {
+      mode = "n";
+      key = "<leader>e";
+      action.__raw = "vim.diagnostic.open_float";
+      options.desc = "Open diagnostic float";
+    }
+    {
+      mode = "n";
+      key = "[d";
+      action.__raw = "vim.diagnostic.goto_prev";
+      options.desc = "Goto next diagnostic";
+    }
+    {
+      mode = "n";
+      key = "]d";
+      action.__raw = "vim.diagnostic.goto_next";
+      options.desc = "Goto previous diagnostic";
+    }
+    {
+      mode = "n";
+      key = "<leader>q";
+      action.__raw = "vim.diagnostic.setloclist";
+      options.desc = "Set loclist with diagnostic locations";
+    }
+
+    # Clear search with <esc>
+    {
+      mode = ["i" "n"];
+      key = "<esc>";
+      action = "<cmd>noh<cr><esc>";
+      options.desc = "Escape and clear hlsearch";
+    }
+
+    # Clear search diff update and redraw
+    # taken from runtime/lua/_editor.lua
+    {
+      mode = "n";
+      key = "<leader>ur";
+      action = "<Cmd>nohlsearch<Bar>diffupdate<Bar>normal! <C-L><CR>";
+      options.desc = "Redraw / clear hlsearch / diff update";
+    }
+
+    {
+      mode = ["n" "x"];
+      key = "gw";
+      action = "*N";
+      options.desc = "Search word under cursor";
+    }
+
+    # https://github.com/mhinz/vim-galore#saner-behavior-of-n-and-n
+    {
+      mode = "n";
+      key = "n";
+      action = "'Nn'[v:searchforward]";
+      options = {
+        expr = true;
+        desc = "Next search result";
+      };
+    }
+    {
+      mode = "x";
+      key = "n";
+      action = "'Nn'[v:searchforward]";
+      options = {
+        expr = true;
+        desc = "Next search result";
+      };
+    }
+    {
+      mode = "o";
+      key = "n";
+      action = "'Nn'[v:searchforward]";
+      options = {
+        expr = true;
+        desc = "Next search result";
+      };
+    }
+    {
+      mode = "n";
+      key = "N";
+      action = "'nN'[v:searchforward]";
+      options = {
+        expr = true;
+        desc = "Prev search result";
+      };
+    }
+    {
+      mode = "x";
+      key = "N";
+      action = "'nN'[v:searchforward]";
+      options = {
+        expr = true;
+        desc = "Prev search result";
+      };
+    }
+    {
+      mode = "o";
+      key = "N";
+      action = "'nN'[v:searchforward]";
+      options = {
+        expr = true;
+        desc = "Prev search result";
+      };
+    }
+
+    {
+      mode = "x";
+      key = ">";
+      action = ">gv";
+      options.desc = "Indent selection";
+    }
+    {
+      mode = "x";
+      key = "<";
+      action = "<gv";
+      options.desc = "Unindent selection";
+    }
+    # Set the K mapping to prevent automapping by nvim
+    {
+      mode = "n";
+      key = "K";
+      action = "<Nop>";
+    }
+  ];
+  autoCmd = [
+    {
+      event = "FileType";
+      pattern = [
+        "checkhealth"
+        "fugitive*"
+        "git"
+        "help"
+        "lspinfo"
+        "netrw"
+        "notify"
+        "qf"
+        "query"
+        "sqls_output"
+      ];
+      callback.__raw = ''
+        function()
+            vim.keymap.set("n", "q", vim.cmd.close, { desc = "Close the current buffer", buffer = true })
+        end
+      '';
+    }
+  ];
+}

--- a/nixvim/config/plugins/autocomplete.nix
+++ b/nixvim/config/plugins/autocomplete.nix
@@ -1,0 +1,38 @@
+{
+  plugins = {
+    friendly-snippets.enable = true;
+    blink-cmp = {
+      enable = true;
+      settings = {
+        signature.enabled = true;
+        appearance.use_nvim_cmp_as_default = true;
+        completion.accept.dot_repeat = false;
+        completion.list.selection = {
+          preselect = false;
+          auto_insert = true;
+        };
+        keymap.__raw = ''
+          {
+            preset = 'enter',
+            ['<Tab>'] = {
+              function(cmp)
+                if cmp.snippet_active() then return
+                else return cmp.select_next() end
+              end,
+              'snippet_forward',
+              'fallback'
+            },
+            ['<S-Tab>'] = {
+              function(cmp)
+                if cmp.snippet_active() then return
+                else return cmp.select_prev() end
+              end,
+              'snippet_backward',
+              'fallback'
+            },
+          }
+        '';
+      };
+    };
+  };
+}

--- a/nixvim/config/plugins/codecompanion.nix
+++ b/nixvim/config/plugins/codecompanion.nix
@@ -1,0 +1,92 @@
+{aitools, ...}: {
+  plugins.codecompanion = {
+    enable = true;
+
+    settings = {
+      log_level = "INFO";
+      interactions = {
+        chat.adapter = "codex";
+        inline.adapter = "openrouter";
+        agent.adapter = "codex";
+      };
+      adapters.acp = {
+        codex.__raw = ''
+          function()
+            return require("codecompanion.adapters").extend("codex", {
+              defaults = {
+                auth_method = "chatgpt"
+              }
+            })
+          end
+        '';
+      };
+      adapters.http = {
+        openrouter.__raw = ''
+          function()
+            return require("codecompanion.adapters").extend("openai_compatible", {
+              env = {
+                url = "https://openrouter.ai/api",
+                api_key = "OPENROUTER_API_KEY",
+                chat_url = "/v1/chat/completions",
+              },
+              schema = {
+                model = {
+                  default = "qwen/qwen3-coder",
+                  choices = {
+                    "x-ai/grok-code-fast-1",
+                    "openai/gpt-5-codex",
+                    "anthropic/claude-sonnet-4.5"
+                  }
+                },
+              }
+            })
+          end
+        '';
+      };
+      display = {
+        diff = {
+          enabled = true;
+          close_chat_at = 240; #Close an open chat buffer if the total columns of your display are less than...
+          provider = "mini_diff"; #default|mini_diff
+        };
+      };
+    };
+  };
+  keymaps = [
+    {
+      mode = ["n" "v"];
+      key = "<C-a>";
+      action = "<cmd>CodeCompanionActions<cr>";
+      options = {
+        noremap = true;
+        silent = true;
+      };
+    }
+    {
+      mode = ["n" "v"];
+      key = "<LocalLeader>a";
+      action = "<cmd>CodeCompanionChat Toggle<cr>";
+      options = {
+        noremap = true;
+        silent = true;
+      };
+    }
+    {
+      mode = "v";
+      key = "ca";
+      action = "<cmd>CodeCompanionChat Add<cr>";
+      options = {
+        noremap = true;
+        silent = true;
+      };
+    }
+  ];
+
+  extraPackages = [
+    aitools.codex-acp
+  ];
+
+  plugins.fidget.luaConfig.post = builtins.readFile ./lua/codecompanion_fidget.lua;
+
+  extraConfigVim = "cabbrev cc CodeCompanion";
+}

--- a/nixvim/config/plugins/conform.nix
+++ b/nixvim/config/plugins/conform.nix
@@ -1,0 +1,10 @@
+{
+  plugins.conform-nvim.enable = true;
+  keymaps = [
+    {
+      key = "<leader>cf";
+      action = ''<cmd>lua require("conform").format({ lsp_fallback = true })<cr>'';
+      options.desc = "Format via Conform";
+    }
+  ];
+}

--- a/nixvim/config/plugins/default.nix
+++ b/nixvim/config/plugins/default.nix
@@ -1,0 +1,34 @@
+{pkgs, ...}: {
+  imports = [
+    ./autocomplete.nix
+    ./codecompanion.nix
+    ./conform.nix
+    ./diffview.nix
+    ./flash.nix
+    ./gitsigns.nix
+    ./lsp.nix
+    ./lualine.nix
+    ./mini.nix
+    ./snacks.nix
+    ./treesitter.nix
+    ./trouble.nix
+    ./ufo.nix
+    ./yanky.nix
+  ];
+
+  plugins = {
+    fidget.enable = true;
+    nvim-bqf.enable = true;
+    render-markdown.enable = true;
+    sqlite-lua.enable = true;
+    ts-comments.enable = true;
+    zen-mode.enable = true;
+  };
+
+  extraPlugins = with pkgs.vimPlugins; [
+    flatten-nvim
+  ];
+  extraConfigLuaPre = ''
+    require('flatten').setup();
+  '';
+}

--- a/nixvim/config/plugins/diffview.nix
+++ b/nixvim/config/plugins/diffview.nix
@@ -1,0 +1,12 @@
+{
+  plugins.diffview = {
+    enable = true;
+    settings = {
+      view = {
+        default.winbarInfo = true;
+        mergeTool.winbarInfo = true;
+        fileHistory.winbarInfo = true;
+      };
+    };
+  };
+}

--- a/nixvim/config/plugins/flash.nix
+++ b/nixvim/config/plugins/flash.nix
@@ -1,0 +1,55 @@
+{
+  plugins.flash.enable = true;
+  keymaps = [
+    {
+      key = "s";
+      mode = ["n" "x" "o"];
+      action.__raw = ''
+        function()
+            require("flash").jump()
+        end
+      '';
+      options.desc = "Flash";
+    }
+    {
+      key = "S";
+      mode = ["n" "x" "o"];
+      action.__raw = ''
+        function()
+            require("flash").treesitter()
+        end
+      '';
+      options.desc = "Flash Treesitter";
+    }
+    {
+      key = "r";
+      mode = "o";
+      action.__raw = ''
+        function()
+          require("flash").remote()
+        end
+      '';
+      options.desc = "Remote Flash";
+    }
+    {
+      key = "R";
+      mode = ["o" "x"];
+      action.__raw = ''
+        function()
+          require("flash").treesitter_search()
+        end
+      '';
+      options.desc = "Treesitter Search";
+    }
+    {
+      key = "<c-s>";
+      mode = ["c"];
+      action.__raw = ''
+        function()
+          require("flash").toggle()
+        end
+      '';
+      options.desc = "Toggle Flash Search";
+    }
+  ];
+}

--- a/nixvim/config/plugins/gitsigns.nix
+++ b/nixvim/config/plugins/gitsigns.nix
@@ -1,0 +1,36 @@
+{
+  plugins.gitsigns = {
+    enable = true;
+    settings.on_attach.__raw = ''
+      function(bufnr)
+        local gs = package.loaded.gitsigns
+
+        local function map(mode, l, r, opts)
+          opts = opts or {}
+          opts.buffer = bufnr
+          vim.keymap.set(mode, l, r, opts)
+        end
+
+        -- Navigation
+        map("n", "]h", gs.next_hunk, { desc = "Next hunk" })
+        map("n", "[h", gs.prev_hunk, { desc = "Prev hunk" })
+
+        -- Actions
+        map({ "n", "v" }, "<leader>hs", ":Gitsigns stage_hunk<CR>", { desc = "Gitsigns stage hunk" })
+        map({ "n", "v" }, "<leader>hr", ":Gitsigns reset_hunk<CR>", { desc = "Gitsigns reset hunk" })
+        map("n", "<leader>hS", gs.stage_buffer, { desc = "Gitsigns stage buffer" })
+        map("n", "<leader>hu", gs.undo_stage_hunk, { desc = "Gitsigns undo stage hunk" })
+        map("n", "<leader>hR", gs.reset_buffer, { desc = "Gitsigns reset buffer" })
+        map("n", "<leader>hp", gs.preview_hunk, { desc = "Gitsigns preview hunk" })
+        map("n", "<leader>hb", function() gs.blame_line({ full = true }) end, { desc = "Gitsigns blame line" })
+        map("n", "<leader>hb", gs.toggle_current_line_blame, { desc = "Gitsigns toggle current line blame" })
+        map("n", "<leader>hd", gs.diffthis, { desc = "Gitsigns diff this" })
+        map("n", "<leader>hD", function() gs.diffthis("~") end, { desc = "Gitsigns diff this ~" })
+        map("n", "<leader>hx", gs.toggle_deleted, { desc = "Gitsigns toggle deleted" })
+
+        -- Text object
+        map({ "o", "x" }, "ih", ":<C-U>Gitsigns select_hunk<CR>", { desc = "Gitsigns select hunk" })
+      end
+    '';
+  };
+}

--- a/nixvim/config/plugins/goose.nix
+++ b/nixvim/config/plugins/goose.nix
@@ -1,0 +1,24 @@
+{
+  pkgs,
+  aitools,
+  ...
+}: {
+  extraPackages = [
+    aitools.goose-cli
+  ];
+  extraPlugins = [
+    (pkgs.vimUtils.buildVimPlugin {
+      name = "goose-nvim";
+      src = pkgs.fetchFromGitHub {
+        owner = "azorng";
+        repo = "goose.nvim";
+        rev = "main";
+        sha256 = "sha256-eCilRNQWTkfC+12vB+S/YoTlxI2EHOFA37Cw5ivaHfM=";
+      };
+      doCheck = false;
+    })
+  ];
+  extraConfigLua = ''
+    require('goose').setup()
+  '';
+}

--- a/nixvim/config/plugins/lsp.nix
+++ b/nixvim/config/plugins/lsp.nix
@@ -1,0 +1,148 @@
+{
+  plugins = {
+    lspconfig.enable = true;
+    lspsaga = {
+      enable = true;
+      settings = {
+        lightbulb.virtualText = false;
+        symbol_in_winbar.enable = true;
+        outline.win_width = 50;
+      };
+    };
+  };
+  autoCmd = [
+    {
+      desc = "Configure LSP keymaps and omnifunc";
+      event = "LspAttach";
+      callback.__raw = ''
+        function(ev)
+          -- Enable completion triggered by <c-x><c-o>
+          vim.bo[ev.buf].omnifunc = "v:lua.vim.lsp.omnifunc"
+        end
+      '';
+    }
+  ];
+  lsp.keymaps = let
+    lspsaga = action: "<cmd>Lspsaga ${action}<cr>";
+  in [
+    {
+      mode = "n";
+      key = "gF";
+      action = lspsaga "finder";
+      options.desc = "Goto symbol finder";
+    }
+    {
+      mode = "n";
+      key = "gl";
+      action = lspsaga "outline";
+      options.desc = "Goto LSP out(l)ine";
+    }
+    {
+      mode = "n";
+      key = "gD";
+      lspBufAction = "declaration";
+      options.desc = "Goto declaration";
+    }
+    {
+      mode = "n";
+      key = "gd";
+      lspBufAction = "definition";
+      options.desc = "Goto definition";
+    }
+    {
+      mode = "n";
+      key = "gI";
+      lspBufAction = "implementation";
+      options.desc = "Goto implementation";
+    }
+    {
+      mode = "n";
+      key = "gt";
+      lspBufAction = "type_definition";
+      options.desc = "Goto type";
+    }
+    {
+      mode = "n";
+      key = "gr";
+      lspBufAction = "references";
+      options.desc = "Goto references";
+    }
+    {
+      mode = "n";
+      key = "K";
+      action = lspsaga "hover_doc";
+    }
+    {
+      mode = ["i" "n"];
+      key = "<C-k>";
+      lspBufAction = "signature_help";
+      options.desc = "Signature help";
+    }
+    {
+      mode = "n";
+      key = "<leader>wa";
+      action.__raw = "vim.lsp.buf.add_workspace_folder";
+      options.desc = "Add workspace folder";
+    }
+    {
+      mode = "n";
+      key = "<leader>wr";
+      action.__raw = "vim.lsp.buf.remove_workspace_folder";
+      options.desc = "Remove workspace folder";
+    }
+    {
+      mode = "n";
+      key = "<leader>wl";
+      action.__raw = ''
+        function()
+          print(vim.inspect(vim.lsp.buf.list_workspace_folders()))
+        end
+      '';
+      options.desc = "Print workspace folders list";
+    }
+    {
+      mode = "n";
+      key = "<leader>gd";
+      action = lspsaga "peek_definition";
+      options.desc = "Peek definition";
+    }
+    {
+      mode = "n";
+      key = "<leader>gy";
+      action = lspsaga "peek_type_definition";
+      options.desc = "Peek t(y)pe definition";
+    }
+    {
+      mode = "n";
+      key = "<leader>gY";
+      action = lspsaga "goto_type_definition";
+      options.desc = "Goto t(y)pe definition";
+    }
+    {
+      mode = "n";
+      key = "<leader>ca";
+      action = lspsaga "code_action";
+      options.desc = "Code action";
+    }
+    {
+      mode = ["n" "v"];
+      key = "<leader>=";
+      lspBufAction = "format";
+      options.desc = "Code format";
+    }
+    {
+      mode = "n";
+      key = "<leader>cr";
+      lspBufAction = "rename";
+      options.desc = "Code rename";
+    }
+  ];
+  keymaps = [
+    {
+      mode = "n";
+      key = "<C-;>";
+      action = "<cmd>Lspsaga term_toggle<cr>";
+      options.desc = "Toggle floating terminal";
+    }
+  ];
+}

--- a/nixvim/config/plugins/lua/codecompanion_fidget.lua
+++ b/nixvim/config/plugins/lua/codecompanion_fidget.lua
@@ -1,0 +1,58 @@
+local CCFidget = {}
+
+
+function CCFidget.start_fidget()
+    local has_fidget, fidget = pcall(require, "fidget")
+    if not has_fidget then
+        return
+    end
+
+    if CCFidget.fidget_progress_handle then
+        CCFidget.fidget_progress_handle.message = "Abort."
+        CCFidget.fidget_progress_handle:cancel()
+        CCFidget.fidget_progress_handle = nil
+    end
+
+    CCFidget.fidget_progress_handle = fidget.progress.handle.create({
+        title = "",
+        message = "Thinking...",
+        lsp_client = { name = "CodeCompanion" },
+    })
+end
+
+function CCFidget.stop_fidget()
+    local has_fidget, _ = pcall(require, "fidget")
+    if not has_fidget then
+        return
+    end
+
+    if CCFidget.fidget_progress_handle then
+        CCFidget.fidget_progress_handle.message = "Done."
+        CCFidget.fidget_progress_handle:finish()
+        CCFidget.fidget_progress_handle = nil
+    end
+end
+
+function CCFidget.setup_fidget()
+    local has_fidget, _ = pcall(require, "fidget")
+    if has_fidget then
+        -- New AU group:
+        local group = vim.api.nvim_create_augroup("CodeCompanionHooks", {})
+
+        -- Attach:
+        vim.api.nvim_create_autocmd({ "User" }, {
+            pattern = "CodeCompanionRequest*",
+            group = group,
+            callback = function(request)
+                if request.match == "CodeCompanionRequestStarted" then
+                    CCFidget.start_fidget()
+                elseif request.match == "CodeCompanionRequestFinished" then
+                    CCFidget.stop_fidget()
+                end
+            end,
+        })
+    end
+end
+
+
+CCFidget.setup_fidget()

--- a/nixvim/config/plugins/lua/mini.lua
+++ b/nixvim/config/plugins/lua/mini.lua
@@ -1,0 +1,98 @@
+--Mini Indentscope
+vim.api.nvim_create_autocmd("FileType", {
+    pattern = { "dbui", "terminal", "help", "alpha", "dashboard", "trouble", "lazy", "mason", "nofile", "snacks_terminal" },
+    callback = function()
+        vim.b.miniindentscope_disable = true
+    end,
+})
+vim.api.nvim_create_autocmd("TermOpen", {
+    callback = function()
+        vim.b.miniindentscope_disable = true
+    end,
+})
+
+-- Mini BufDelete
+local function bufdelete(force)
+    return function()
+        MiniBufremove.delete(nil, force)
+    end
+end
+vim.keymap.set("n", "<leader>bd", bufdelete(false), { desc = "Delete buffer" })
+vim.keymap.set("n", "<leader>bD", bufdelete(true), { desc = "Force delete buffer" })
+
+-- Mini Files Vinegar minus
+local function mini_minus()
+    MiniFiles.open(vim.api.nvim_buf_get_name(0))
+end
+vim.keymap.set("n", "-", mini_minus, { desc = "Open Mini Files over current file" })
+
+-- Mini Files explorer buffer customization
+local show_dotfiles = false 
+local filter_show = function(fs_entry)
+    return true
+end
+local filter_hide = function(fs_entry)
+    return not vim.startswith(fs_entry.name, ".")
+end
+local toggle_dotfiles = function()
+    show_dotfiles = not show_dotfiles
+    local new_filter = show_dotfiles and filter_show or filter_hide
+    MiniFiles.refresh({ content = { filter = new_filter } })
+end
+local function mini_enter()
+    MiniFiles.go_in({ close_on_file = true })
+end
+local function map_split(buf_id, lhs, direction)
+    local rhs = function()
+        -- Make new window and set it as target
+        local new_target_window
+        local exp_target_window = MiniFiles.get_explorer_state().target_window
+        vim.api.nvim_win_call(exp_target_window, function()
+            vim.cmd(direction .. " split")
+            new_target_window = vim.api.nvim_get_current_win()
+        end)
+
+        MiniFiles.set_target_window(new_target_window)
+        mini_enter()
+    end
+
+    -- Adding `desc` will result into `show_help` entries
+    local desc = "Split " .. direction
+    vim.keymap.set("n", lhs, rhs, { buffer = buf_id, desc = desc })
+end
+vim.api.nvim_create_autocmd("User", {
+    pattern = "MiniFilesBufferCreate",
+    callback = function(args)
+        local buf_id = args.data.buf_id
+        vim.keymap.set("n", "g.", toggle_dotfiles, { buffer = buf_id })
+        vim.keymap.set("n", "-", MiniFiles.go_out, { buffer = buf_id })
+        vim.keymap.set("n", "<CR>", mini_enter, { buffer = buf_id })
+        map_split(buf_id, "<C-x>", "belowright horizontal")
+        map_split(buf_id, "<C-v>", "belowright vertical")
+    end,
+})
+
+-- Mini Pick
+vim.ui.select = require("mini.pick").ui_select
+local choose_all = function()
+  local matches = MiniPick.get_picker_matches().all
+  MiniPick.default_choose_marked(matches)
+end
+require('mini.pick').setup({
+  mappings = {
+    choose_all = { char = '<C-q>', func = choose_all },
+  },
+})
+
+-- Mini Starter
+require("mini.starter").setup({
+    items = {
+    function()
+      if _G.MiniSessions == nil then return {} end
+      return MiniStarter.sections.sessions(5, true)()
+    end,
+    MiniStarter.sections.recent_files(5, true, true),
+    MiniStarter.sections.pick(),
+    MiniStarter.sections.builtin_actions(),
+  }
+})

--- a/nixvim/config/plugins/lualine.nix
+++ b/nixvim/config/plugins/lualine.nix
@@ -1,0 +1,8 @@
+{
+  plugins.lualine = {
+    enable = true;
+    settings = {
+      globalstatus = true;
+    };
+  };
+}

--- a/nixvim/config/plugins/mini.nix
+++ b/nixvim/config/plugins/mini.nix
@@ -1,0 +1,238 @@
+{lib, ...}: let
+  raw = lib.nixvim.mkRaw;
+in {
+  plugins.mini = {
+    enable = true;
+    mockDevIcons = true;
+    modules = {
+      basics = {
+        extra_ui = true;
+      };
+      bufremove = {};
+      bracketed = {};
+      clue = {
+        triggers = [
+          # Leader trigger
+          {
+            mode = "n";
+            keys = "<Leader>";
+          }
+          {
+            mode = "x";
+            keys = "<Leader>";
+          }
+
+          # Built-in completion
+          {
+            mode = "i";
+            keys = "<C-x>";
+          }
+
+          # `g` key
+          {
+            mode = "n";
+            keys = "g";
+          }
+          {
+            mode = "x";
+            keys = "g";
+          }
+
+          # Mark
+          {
+            mode = "n";
+            keys = "'";
+          }
+          {
+            mode = "n";
+            keys = "`";
+          }
+          {
+            mode = "x";
+            keys = "'";
+          }
+          {
+            mode = "x";
+            keys = "`";
+          }
+
+          # Register
+          {
+            mode = "n";
+            keys = "\"";
+          }
+          {
+            mode = "x";
+            keys = "\"";
+          }
+          {
+            mode = "i";
+            keys = "<C-r>";
+          }
+          {
+            mode = "c";
+            keys = "<C-r>";
+          }
+
+          # Window command
+          {
+            mode = "n";
+            keys = "<C-w>";
+          }
+
+          # `z` ke
+          {
+            mode = "n";
+            keys = "z";
+          }
+          {
+            mode = "x";
+            keys = "z";
+          }
+
+          # `Brackets
+          {
+            mode = "n";
+            keys = "[";
+          }
+          {
+            mode = "n";
+            keys = "]";
+          }
+          {
+            mode = "x";
+            keys = "[";
+          }
+          {
+            mode = "x";
+            keys = "]";
+          }
+        ];
+        clues = let
+          clue = "require('mini.clue')";
+        in [
+          # Enhance this by adding descriptions for <Leader> mapping groups
+          (raw "${clue}.gen_clues.builtin_completion()")
+          (raw "${clue}.gen_clues.g()")
+          (raw "${clue}.gen_clues.marks()")
+          (raw "${clue}.gen_clues.registers()")
+          (raw "${clue}.gen_clues.windows()")
+          (raw "${clue}.gen_clues.z()")
+
+          # Submode for quick buffer navigation
+          {
+            mode = "n";
+            keys = "]b";
+            postkeys = "]";
+          }
+          {
+            mode = "n";
+            keys = "]w";
+            postkeys = "]";
+          }
+          {
+            mode = "n";
+            keys = "[b";
+            postkeys = "[";
+          }
+          {
+            mode = "n";
+            keys = "[w";
+            postkeys = "[";
+          }
+        ];
+      };
+      comment = {};
+      diff = {};
+      extra = {};
+      files = {};
+      icons = {};
+      indentscope = {
+        try_as_border = true;
+      };
+      pick = {};
+      pairs = {};
+      starter = {};
+      surround = {
+        mappings = {
+          add = "gsa";
+          delete = "gsd";
+          find = "gsf";
+          find_left = "gsF";
+          highlight = "gsh";
+          replace = "gsr";
+          update_n_lines = "gsn";
+        };
+      };
+      visits = {};
+    };
+    luaConfig.post = builtins.readFile ./lua/mini.lua;
+  };
+  keymaps = [
+    {
+      key = "<leader>ff";
+      action = raw "MiniPick.builtin.files";
+      options.desc = "Pick files";
+    }
+    {
+      key = "<leader>fe";
+      action = raw "MiniExtra.pickers.explorer";
+      options.desc = "Pick file explorer";
+    }
+    {
+      key = "<leader>fv";
+      action = raw "MiniExtra.pickers.visit_paths";
+      options.desc = "Pick frecent files";
+    }
+    {
+      key = "<leader>fl";
+      action = raw "MiniExtra.pickers.visit_labels";
+      options.desc = "Pick frecent labels";
+    }
+    {
+      key = "<leader>bb";
+      action = raw "MiniPick.builtin.buffers";
+      options.desc = "Pick buffers";
+    }
+    {
+      key = "<leader>sg";
+      action = raw "MiniPick.builtin.grep_live";
+      options.desc = "Pick by grep (live)";
+    }
+    {
+      key = "<leader>\"";
+      action = raw "MiniExtra.pickers.registers";
+      options.desc = "Pick registers";
+    }
+    {
+      key = "<leader>sl";
+      action = raw "MiniExtra.pickers.lsp";
+      options.desc = "Pick LSP symbols";
+    }
+    {
+      key = "<leader>sk";
+      action = raw "MiniExtra.pickers.keymaps";
+      options.desc = "Pick keymaps";
+    }
+    {
+      key = "<leader>fo";
+      action = raw "MiniExtra.pickers.oldfiles";
+      options.desc = "Pick oldfiles";
+    }
+    {
+      key = "<leader>st";
+      action = raw "MiniExtra.pickers.treesitter";
+      options.desc = "Pick code (nodes)";
+    }
+    {
+      key = "<leader>sc";
+      action = raw "function() MiniExtra.pickers.history({ scope = ':' }) end";
+      options.desc = "Pick command (history)";
+    }
+    {
+      key = "<leader>s/";
+      action = raw "function() MiniExtra.pickers.history({ scope = '/' }) end";
+      options.desc = "Pick command (search)";
+    }
+  ];
+}

--- a/nixvim/config/plugins/snacks.nix
+++ b/nixvim/config/plugins/snacks.nix
@@ -1,0 +1,3 @@
+{
+  plugins.snacks.enable = true;
+}

--- a/nixvim/config/plugins/treesitter.nix
+++ b/nixvim/config/plugins/treesitter.nix
@@ -1,0 +1,29 @@
+{pkgs, ...}: let
+  grammarPkgs = pkgs.vimPlugins.nvim-treesitter.allGrammars;
+in {
+  plugins.treesitter-textobjects.enable = true;
+  plugins.ts-autotag.enable = true;
+  plugins.treesitter-context = {
+    enable = true;
+    settings = {
+      mode = "cursor";
+    };
+  };
+  plugins.treesitter = {
+    enable = true;
+    grammarPackages = grammarPkgs;
+    settings = {
+      highlight.enable = true;
+      indent.enable = true;
+      incremental_selection = {
+        enable = true;
+        keymaps = {
+          init_selection = "<C-space>";
+          node_incremental = "<C-space>";
+          scope_incremental = false;
+          node_decremental = "<bs>";
+        };
+      };
+    };
+  };
+}

--- a/nixvim/config/plugins/trouble.nix
+++ b/nixvim/config/plugins/trouble.nix
@@ -1,0 +1,67 @@
+{
+  plugins.trouble.enable = true;
+  keymaps = [
+    {
+      key = "<leader>xx";
+      action = "<cmd>Trouble diagnostics toggle<cr>";
+      options.desc = "Diagnostics (Trouble)";
+    }
+    {
+      key = "<leader>xX";
+      action = "<cmd>Trouble diagnostics toggle filter.buf=0<cr>";
+      options.desc = "Buffer Diagnostics (Trouble)";
+    }
+    {
+      key = "<leader>cs";
+      action = "<cmd>Trouble symbols toggle focus=false win.size=50<cr>";
+      options.desc = "Symbols (Trouble)";
+    }
+    {
+      key = "<leader>cS";
+      action = "<cmd>Trouble lsp toggle focus=false win.position=right<cr>";
+      options.desc = "LSP references/definitions/... (Trouble)";
+    }
+    {
+      key = "<leader>xL";
+      action = "<cmd>Trouble loclist toggle<cr>";
+      options.desc = "Location List (Trouble)";
+    }
+    {
+      key = "<leader>xQ";
+      action = "<cmd>Trouble qflist toggle<cr>";
+      options.desc = "Quickfix List (Trouble)";
+    }
+    {
+      key = "[q";
+      action.__raw = ''
+        function()
+          if require("trouble").is_open() then
+            require("trouble").prev({ skip_groups = true, jump = true })
+          else
+            local ok, err = pcall(vim.cmd.cprev)
+            if not ok then
+                vim.notify(err, vim.log.levels.ERROR)
+            end
+          end
+        end
+      '';
+      options.desc = "Previous Trouble/Quickfix Item";
+    }
+    {
+      key = "]q";
+      action.__raw = ''
+        function()
+            if require("trouble").is_open() then
+                require("trouble").next({ skip_groups = true, jump = true })
+            else
+                local ok, err = pcall(vim.cmd.cnext)
+                if not ok then
+                    vim.notify(err, vim.log.levels.ERROR)
+                end
+            end
+        end
+      '';
+      options.desc = "Next Trouble/Quickfix Item";
+    }
+  ];
+}

--- a/nixvim/config/plugins/ufo.nix
+++ b/nixvim/config/plugins/ufo.nix
@@ -1,0 +1,69 @@
+{
+  plugins.nvim-ufo = {
+    enable = true;
+    setupLspCapabilities = true;
+    settings = {
+      fold_virt_text_handler.__raw = ''
+        function(virtText, lnum, endLnum, width, truncate)
+          local newVirtText = {}
+          local suffix = (' 󰁂 %d '):format(endLnum - lnum)
+          local sufWidth = vim.fn.strdisplaywidth(suffix)
+          local targetWidth = width - sufWidth
+          local curWidth = 0
+          for _, chunk in ipairs(virtText) do
+              local chunkText = chunk[1]
+              local chunkWidth = vim.fn.strdisplaywidth(chunkText)
+              if targetWidth > curWidth + chunkWidth then
+                  table.insert(newVirtText, chunk)
+              else
+                  chunkText = truncate(chunkText, targetWidth - curWidth)
+                  local hlGroup = chunk[2]
+                  table.insert(newVirtText, {chunkText, hlGroup})
+                  chunkWidth = vim.fn.strdisplaywidth(chunkText)
+                  -- str width returned from truncate() may less than 2nd argument, need padding
+                  if curWidth + chunkWidth < targetWidth then
+                      suffix = suffix .. (' '):rep(targetWidth - curWidth - chunkWidth)
+                  end
+                  break
+              end
+              curWidth = curWidth + chunkWidth
+          end
+          table.insert(newVirtText, {suffix, 'MoreMsg'})
+          return newVirtText
+        end
+      '';
+    };
+  };
+  keymaps = [
+    {
+      key = "zR";
+      action.__raw = "require('ufo').openAllFolds";
+      mode = "n";
+      options.desc = "Open all folds";
+    }
+    {
+      key = "zM";
+      action.__raw = "require('ufo').closeAllFolds";
+      mode = "n";
+      options.desc = "Close all folds";
+    }
+    {
+      key = "zr";
+      action.__raw = "require('ufo').openFoldsExceptKinds";
+      mode = "n";
+      options.desc = "Open folds except kinds";
+    }
+    {
+      key = "zm";
+      action.__raw = "require('ufo').closeFoldsWith";
+      mode = "n";
+      options.desc = "Close folds with";
+    }
+    {
+      key = "zp";
+      action.__raw = "require('ufo').peekFoldedLinesUnderCursor";
+      mode = "n";
+      options.desc = "Peek folded lines under cursor";
+    }
+  ];
+}

--- a/nixvim/config/plugins/yanky.nix
+++ b/nixvim/config/plugins/yanky.nix
@@ -1,0 +1,107 @@
+{
+  plugins.yanky = {
+    enable = true;
+    settings = {
+      highlight = {timer = 250;};
+      ring = {storage = "sqlite";};
+    };
+  };
+  keymaps = [
+    {
+      key = "<leader>y";
+      action = "<cmd>YankyRingHistory<CR>";
+      mode = ["n" "x"];
+      options.desc = "Show Yank history";
+    }
+    {
+      key = "y";
+      action = "<Plug>(YankyYank)";
+      mode = ["n" "x"];
+      options.desc = "Yank text";
+    }
+    {
+      key = "p";
+      action = "<Plug>(YankyPutAfter)";
+      mode = ["n" "x"];
+      options.desc = "Put yanked text after cursor";
+    }
+    {
+      key = "P";
+      action = "<Plug>(YankyPutBefore)";
+      mode = ["n" "x"];
+      options.desc = "Put yanked text before cursor";
+    }
+    {
+      key = "gp";
+      action = "<Plug>(YankyGPutAfter)";
+      mode = ["n" "x"];
+      options.desc = "Put yanked text after selection";
+    }
+    {
+      key = "gP";
+      action = "<Plug>(YankyGPutBefore)";
+      mode = ["n" "x"];
+      options.desc = "Put yanked text before selection";
+    }
+    {
+      key = "[y";
+      action = "<Plug>(YankyCycleForward)";
+      options.desc = "Cycle forward through yank history";
+    }
+    {
+      key = "]y";
+      action = "<Plug>(YankyCycleBackward)";
+      options.desc = "Cycle backward through yank history";
+    }
+    {
+      key = "]p";
+      action = "<Plug>(YankyPutIndentAfterLinewise)";
+      options.desc = "Put indented after cursor (linewise)";
+    }
+    {
+      key = "[p";
+      action = "<Plug>(YankyPutIndentBeforeLinewise)";
+      options.desc = "Put indented before cursor (linewise)";
+    }
+    {
+      key = "]P";
+      action = "<Plug>(YankyPutIndentAfterLinewise)";
+      options.desc = "Put indented after cursor (linewise)";
+    }
+    {
+      key = "[P";
+      action = "<Plug>(YankyPutIndentBeforeLinewise)";
+      options.desc = "Put indented before cursor (linewise)";
+    }
+    {
+      key = ">p";
+      action = "<Plug>(YankyPutIndentAfterShiftRight)";
+      options.desc = "Put and indent right";
+    }
+    {
+      key = "<p";
+      action = "<Plug>(YankyPutIndentAfterShiftLeft)";
+      options.desc = "Put and indent left";
+    }
+    {
+      key = ">P";
+      action = "<Plug>(YankyPutIndentBeforeShiftRight)";
+      options.desc = "Put before and indent right";
+    }
+    {
+      key = "<P";
+      action = "<Plug>(YankyPutIndentBeforeShiftLeft)";
+      options.desc = "Put before and indent left";
+    }
+    {
+      key = "=p";
+      action = "<Plug>(YankyPutAfterFilter)";
+      options.desc = "Put after applying a filter";
+    }
+    {
+      key = "=P";
+      action = "<Plug>(YankyPutBeforeFilter)";
+      options.desc = "Put before applying a filter";
+    }
+  ];
+}

--- a/nixvim/lang/dap.nix
+++ b/nixvim/lang/dap.nix
@@ -1,0 +1,127 @@
+{
+  plugins = {
+    dap.enable = true;
+    dap-ui.enable = true;
+    dap-virtual-text.enable = true;
+  };
+  keymaps = [
+    {
+      key = "<leader>dR";
+      action.__raw = ''function() require("dap").run_to_cursor() end'';
+      options.desc = "Run to Cursor";
+    }
+    {
+      key = "<leader>dE";
+      action.__raw = ''function() require("dapui").eval(vim.fn.input "[Expression] > ") end'';
+      options.desc = "Evaluate Input";
+    }
+    {
+      key = "<leader>dC";
+      action.__raw = ''function() require("dap").set_breakpoint(vim.fn.input "[Condition] > ") end'';
+      options.desc = "Conditional Breakpoint";
+    }
+    {
+      key = "<leader>dU";
+      action.__raw = ''function() require("dapui").toggle() end'';
+      options.desc = "Toggle UI";
+    }
+    {
+      key = "<leader>db";
+      action.__raw = ''function() require("dap").step_back() end'';
+      options.desc = "Step Back";
+    }
+    {
+      key = "<leader>dc";
+      action.__raw = ''function() require("dap").continue() end'';
+      options.desc = "Continue";
+    }
+    {
+      key = "<leader>dd";
+      action.__raw = ''function() require("dap").disconnect() end'';
+      options.desc = "Disconnect";
+    }
+    {
+      key = "<leader>de";
+      action.__raw = ''function() require("dapui").eval() end'';
+      mode = ["n" "v"];
+      options.desc = "Evaluate";
+    }
+    {
+      key = "<leader>dg";
+      action.__raw = ''function() require("dap").session() end'';
+      options.desc = "Get Session";
+    }
+    {
+      key = "<leader>dh";
+      action.__raw = ''function() require("dap.ui.widgets").hover() end'';
+      options.desc = "Hover Variables";
+    }
+    {
+      key = "<leader>dS";
+      action.__raw = ''function() require("dap.ui.widgets").scopes() end'';
+      options.desc = "Scopes";
+    }
+    {
+      key = "<leader>di";
+      action.__raw = ''function() require("dap").step_into() end'';
+      options.desc = "Step Into";
+    }
+    {
+      key = "<leader>do";
+      action.__raw = ''function() require("dap").step_over() end'';
+      options.desc = "Step Over";
+    }
+    {
+      key = "<leader>dp";
+      action.__raw = ''function() require("dap").pause.toggle() end'';
+      options.desc = "Pause";
+    }
+    {
+      key = "<leader>dq";
+      action.__raw = ''function() require("dap").close() end'';
+      options.desc = "Quit";
+    }
+    {
+      key = "<leader>dr";
+      action.__raw = ''function() require("dap").repl.toggle() end'';
+      options.desc = "Toggle REPL";
+    }
+    {
+      key = "<leader>ds";
+      action.__raw = ''function() require("dap").continue() end'';
+      options.desc = "Start";
+    }
+    {
+      key = "<leader>dt";
+      action.__raw = ''function() require("dap").toggle_breakpoint() end'';
+      options.desc = "Toggle Breakpoint";
+    }
+    {
+      key = "<leader>dx";
+      action.__raw = ''function() require("dap").terminate() end'';
+      options.desc = "Terminate";
+    }
+    {
+      key = "<leader>du";
+      action.__raw = ''function() require("dap").step_out() end'';
+      options.desc = "Step Out";
+    }
+    {
+      key = "<leader>td";
+      action.__raw = ''function() require("neotest").run.run({ strategy = "dap" }) end'';
+      options.desc = "Debug Nearest";
+    }
+  ];
+  extraConfigLua = ''
+    local dap, dapui = require("dap"), require("dapui")
+    dap.listeners.after.event_initialized["dapui_config"] = function()
+        dapui.open()
+    end
+    dap.listeners.before.event_terminated["dapui_config"] = function()
+        dapui.close()
+    end
+    dap.listeners.before.event_exited["dapui_config"] = function()
+        dapui.close()
+    end
+  '';
+}

--- a/nixvim/lang/golang.nix
+++ b/nixvim/lang/golang.nix
@@ -1,0 +1,7 @@
+{pkgs, ...}: {
+  lsp.servers.gopls.enable = true;
+  extraPackages = with pkgs; [
+    gomodifytags
+    reftools
+  ];
+}

--- a/nixvim/lang/json.nix
+++ b/nixvim/lang/json.nix
@@ -1,0 +1,6 @@
+{pkgs, ...}: {
+  plugins.conform-nvim.settings.formatters_by_ft.json = ["jq"];
+  extraPackages = [
+    pkgs.jq
+  ];
+}

--- a/nixvim/lang/markdown.nix
+++ b/nixvim/lang/markdown.nix
@@ -1,0 +1,19 @@
+{pkgs, ...}: {
+  plugins.conform-nvim.settings.formatters_by_ft.markdown = ["mdformat"];
+  extraPackages = [
+    pkgs.mdformat
+  ];
+  autoCmd = [
+    {
+      event = "FileType";
+      pattern = "markdown";
+      callback.__raw = ''
+        function()
+            vim.api.nvim_buf_set_option(0, 'textwidth', 100)
+            vim.api.nvim_buf_set_option(0, 'wrap', true)
+            vim.api.nvim_buf_set_option(0, 'linebreak', true)
+        end
+      '';
+    }
+  ];
+}

--- a/nixvim/lang/nixlang.nix
+++ b/nixvim/lang/nixlang.nix
@@ -1,0 +1,21 @@
+{pkgs, ...}: {
+  lsp.servers.nixd.enable = true;
+  plugins.conform-nvim.settings.formatters_by_ft.nix = ["alejandra"];
+  extraPackages = with pkgs; [
+    alejandra
+  ];
+  autoCmd = [
+    {
+      event = "FileType";
+      pattern = "nix";
+      callback.__raw = ''
+        function()
+            vim.api.nvim_buf_set_option(0, 'shiftwidth', 2)
+            vim.api.nvim_buf_set_option(0, 'shiftwidth', 2)
+            vim.api.nvim_buf_set_option(0, 'tabstop', 2)
+            vim.api.nvim_buf_set_option(0, 'softtabstop', 2)
+        end
+      '';
+    }
+  ];
+}

--- a/nixvim/lang/prolog.nix
+++ b/nixvim/lang/prolog.nix
@@ -1,0 +1,4 @@
+{
+  lsp.enable = true;
+  lsp.servers.prolog_ls.enable = true;
+}

--- a/nixvim/lang/python.nix
+++ b/nixvim/lang/python.nix
@@ -1,0 +1,18 @@
+{pkgs, ...}: {
+  # DAP support
+  imports = [./dap.nix];
+  plugins.dap-python.enable = true;
+  inherit (import ./dap.nix) keymaps;
+
+  # LSP config with ty and ruff
+  lsp = {
+    servers.basedpyright.enable = true;
+    servers.ruff.enable = true;
+  };
+
+  # conform setup
+  plugins.conform-nvim.settings.formatters_by_ft.python = ["isort"];
+  extraPackages = with pkgs; [
+    isort
+  ];
+}

--- a/nixvim/lang/sql.nix
+++ b/nixvim/lang/sql.nix
@@ -1,0 +1,10 @@
+{pkgs, ...}: {
+  plugins = {
+    conform-nvim.settings.formatters_by_ft.sql = [
+      "sleek"
+    ];
+  };
+  extraPackages = with pkgs; [
+    sleek
+  ];
+}

--- a/nixvim/lang/web.nix
+++ b/nixvim/lang/web.nix
@@ -1,0 +1,22 @@
+{
+  pkgs,
+  lib,
+  ...
+}: {
+  lsp.servers = {
+    emmet_language_server.enable = true;
+    ts_ls.enable = true;
+  };
+
+  # conform setup
+  plugins.conform-nvim.settings.formatters_by_ft = lib.genAttrs [
+    "css"
+    "html"
+    "javascript"
+    "typescript"
+  ] (ft: ["biome"]);
+  extraPackages = with pkgs; [
+    bun
+    biome
+  ];
+}

--- a/programs/default.nix
+++ b/programs/default.nix
@@ -73,7 +73,7 @@
     ssh = {
       enable = true;
       enableDefaultConfig = false;
-      matchBlocks."*".addKeysToAgent = "yes";
+      settings."*".AddKeysToAgent = "yes";
     };
 
     keychain = {

--- a/programs/yazi.nix
+++ b/programs/yazi.nix
@@ -2,6 +2,7 @@
   programs.yazi = {
     enable = true;
     enableZshIntegration = true;
+    shellWrapperName = "yy";
     plugins = let
       yp = pkgs.yaziPlugins;
     in {

--- a/programs/zsh.nix
+++ b/programs/zsh.nix
@@ -24,6 +24,7 @@
       shellAliases = {
         j = "z";
         e = "$EDITOR";
+        keeper = "uvx --from keepercommander keeper";
       };
       envExtra = ''
         if [[ -f "$HOME/.zshkeys" ]]; then


### PR DESCRIPTION
## Summary

- merge the mynixvim configuration into mynixhome under nixvim/
- expose local standalone nvim packages while keeping the home-manager package default
- install Neovim through nixvim's Home Manager module with all language modules enabled by default
- make current GTK4, SSH, and Yazi legacy defaults explicit to silence deprecation/default warnings

## Validation

- nix eval .#packages.aarch64-darwin.nvim.drvPath --raw
- nix eval .#packages.x86_64-linux.nvim.drvPath --raw
- nix eval .#packages.aarch64-darwin.nvim-nixlang.drvPath --raw
- nix eval .#packages.aarch64-darwin.default.drvPath --raw
- nix eval .#checks.aarch64-darwin.nvim.drvPath --raw
- nix eval .#homeConfigurations.markbaran.activationPackage.drvPath --raw
- nix eval .#homeConfigurations.mebaran.activationPackage.drvPath --raw
- nix eval .#homeConfigurations.mbaran.activationPackage.drvPath --raw
- nix flake show --json