### PR TITLE
[codex] fix skill source updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 NIX_UPDATE ?= nix run nixpkgs\#nix-update --
-SKILL_SOURCE_PACKAGES := openai-skills duckdb-skills aws-agent-toolkit-for-aws
+SKILL_SOURCE_PACKAGES := openai-skills duckdb-skills aws-agent-toolkit-for-aws pydantic-skills
 
 .PHONY: update-home-manager update-skills update-weekly
 

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,13 @@
 NIX_UPDATE ?= nix run nixpkgs\#nix-update --
-SKILL_SOURCE_PACKAGES := openai-skills duckdb-skills aws-agent-toolkit-for-aws lean-ctx
+SKILL_SOURCE_PACKAGES := openai-skills duckdb-skills aws-agent-toolkit-for-aws
 
 .PHONY: update-home-manager update-skills update-weekly
 
 update-skills:
-	$(NIX_UPDATE) --flake --version=branch --src-only --override-filename packages/skill-sources.nix openai-skills duckdb-skills aws-agent-toolkit-for-aws
-	$(NIX_UPDATE) --flake --version=latest --src-only --override-filename packages/skill-sources.nix lean-ctx
+	@for pkg in $(SKILL_SOURCE_PACKAGES); do \
+		$(NIX_UPDATE) --flake --version=branch --src-only --override-filename packages/skill-sources.nix $$pkg; \
+	done
+	$(NIX_UPDATE) --flake --src-only --override-filename packages/lean-ctx.nix lean-ctx
 
 update-home-manager:
 	nix flake update

--- a/flake.nix
+++ b/flake.nix
@@ -75,12 +75,14 @@
         };
       };
       skillSources = import ./packages/skill-sources.nix {inherit pkgs;};
+      lean-ctx = pkgs.callPackage ./packages/lean-ctx.nix {};
       baseNvim = nixvim'.makeNixvimWithModule nixvimModule;
       allLangNvim = lib.foldl (n: l: n.extend l) baseNvim (lib.attrValues nvimLangs);
       nvimPackages =
         {
           nvim = allLangNvim;
           nvim-all = allLangNvim;
+          inherit lean-ctx;
         }
         // lib.mapAttrs' (name: value:
           lib.nameValuePair "nvim-${name}" (baseNvim.extend value))

--- a/packages/skill-sources.nix
+++ b/packages/skill-sources.nix
@@ -47,4 +47,18 @@ in {
 
     installPhase = installWithoutReadmes;
   };
+
+  pydantic-skills = pkgs.stdenvNoCC.mkDerivation {
+    pname = "pydantic-skills";
+    version = "0-unstable-2026-06-10";
+
+    src = pkgs.fetchFromGitHub {
+      owner = "pydantic";
+      repo = "skills";
+      rev = "1e7a4567d8375e8ef07ad078d7f38bc03ce5e944";
+      hash = "sha256-PzuqYip+2lrJSgk2/e2x6Npe13r3txjLKzYIAOUHTpI=";
+    };
+
+    installPhase = installWithoutReadmes;
+  };
 }

--- a/packages/skill-sources.nix
+++ b/packages/skill-sources.nix
@@ -1,4 +1,11 @@
-{pkgs}: {
+{pkgs}: let
+  installWithoutReadmes = ''
+    runHook preInstall
+    cp -R . "$out"
+    find "$out" -type f \( -iname README -o -iname 'README.*' \) -delete
+    runHook postInstall
+  '';
+in {
   openai-skills = pkgs.stdenvNoCC.mkDerivation {
     pname = "openai-skills";
     version = "0-unstable-2026-05-29";
@@ -10,11 +17,7 @@
       hash = "sha256-drA/ypVE+yK4W2Bj8IUtWaVLF390Pfy7YLcmdju5dow=";
     };
 
-    installPhase = ''
-      runHook preInstall
-      cp -R . "$out"
-      runHook postInstall
-    '';
+    installPhase = installWithoutReadmes;
   };
 
   duckdb-skills = pkgs.stdenvNoCC.mkDerivation {
@@ -28,28 +31,20 @@
       hash = "sha256-OmsODyirf2MzmoDMRx+c8xbkJWq2qOlMhXjKDV7PUv4=";
     };
 
-    installPhase = ''
-      runHook preInstall
-      cp -R . "$out"
-      runHook postInstall
-    '';
+    installPhase = installWithoutReadmes;
   };
 
   aws-agent-toolkit-for-aws = pkgs.stdenvNoCC.mkDerivation {
     pname = "aws-agent-toolkit-for-aws";
-    version = "0-unstable-2026-06-03";
+    version = "0-unstable-2026-06-09";
 
     src = pkgs.fetchFromGitHub {
       owner = "aws";
       repo = "agent-toolkit-for-aws";
-      rev = "df13dea64baaa1b7031b25d1b2f380756131efec";
-      hash = "sha256-LuUkZS0anep1bbrybbu7KCZsTVLP5/nbQN6Ivl6PLv0=";
+      rev = "c0991f463b54ac94af32a730d6d13293dcff98cf";
+      hash = "sha256-QiR07nlnajVu50hAeOizj5qhMkbOWKmD1bpkb1Y2c2c=";
     };
 
-    installPhase = ''
-      runHook preInstall
-      cp -R . "$out"
-      runHook postInstall
-    '';
+    installPhase = installWithoutReadmes;
   };
 }

--- a/programs/skills.nix
+++ b/programs/skills.nix
@@ -96,6 +96,7 @@ in rec {
     "${skillSources.duckdb-skills}"
     "${skillSources.duckdb-skills}/skills"
     "${skillSources.aws-agent-toolkit-for-aws}/skills"
+    "${skillSources.pydantic-skills}/skills"
   ];
 
   managedSkills =


### PR DESCRIPTION
## Summary

- Fix `make update-skills` so `nix-update` is called once per package.
- Expose `lean-ctx` as a flake package so it can be updated by the Makefile target.
- Strip README files from installed skill source package outputs to avoid confusing the Pi loader.
- Update `aws-agent-toolkit-for-aws` to `0-unstable-2026-06-09`.

## Validation

- `make update-skills`
- `nix build .#openai-skills .#duckdb-skills .#aws-agent-toolkit-for-aws`
- `find result result-1 result-2 -type f \( -iname README -o -iname 'README.*' \) -print`
