### PR TITLE
[codex] Organize Pi skills declaratively

### DIFF
--- a/programs/pi.nix
+++ b/programs/pi.nix
@@ -13,12 +13,20 @@
   pi = lib.getExe piPkg;
   npx = "${pkgs.nodejs}/bin/npx";
 
-  piSkills = import ./skills.nix {inherit skillSources;};
+  piSkills = import ./skills.nix {inherit lib skillSources;};
 
   # Skills installed by `npx skills add ... -g` normally land here.
   skillPath = name: "$HOME/.agents/skills/${name}";
   skillPaths = names: map skillPath names;
   skillInstallLine = skill: "${npx} --yes skills add ${lib.escapeShellArg skill.source} -g -y";
+  skillsForPackNames = packNames:
+    lib.concatLists (map (name: let
+      pack = piSkills.skillPacks.${name};
+    in
+      (skillPaths pack.skillNames) ++ pack.skillPaths)
+    packNames);
+  defaultSkills = skillsForPackNames piSkills.defaultSkillPackNames;
+  profileSkills = name: skillsForPackNames piSkills.profilePackNames.${name};
 
   piSkillsInstall = pkgs.writeShellApplication {
     name = "pi-skills-install";
@@ -40,6 +48,113 @@
     '';
   };
 
+  projectPackManifests = lib.mapAttrs (name: pack:
+    pkgs.writeText "pi-pack-${name}.json" (builtins.toJSON {
+      inherit name;
+      inherit (pack) description skills plugins;
+    }))
+  piSkills.projectPacks;
+
+  projectPackList = lib.concatStringsSep "\n" (lib.mapAttrsToList (name: pack: "${name}\t${pack.description}") piSkills.projectPacks);
+  projectPackInstallCases = lib.concatStringsSep "\n" (lib.mapAttrsToList (name: pack: ''
+      ${lib.escapeShellArg name})
+        install -d "$target/.agents/skills" "$target/.agents/plugins" "$target/.agents/pi-packs"
+        ${lib.concatMapStringsSep "\n" (skill: "link_entry \"$target/.agents/skills/${skill.name}\" ${lib.escapeShellArg skill.path}") pack.skills}
+        ${lib.concatMapStringsSep "\n" (plugin: "link_entry \"$target/.agents/plugins/${plugin.name}\" ${lib.escapeShellArg plugin.path}") pack.plugins}
+        cp ${projectPackManifests.${name}} "$target/.agents/pi-packs/${name}.json"
+        echo "installed Pi pack '${name}' into $target"
+        ;;
+    '')
+    piSkills.projectPacks);
+  projectPackShowCases = lib.concatStringsSep "\n" (lib.mapAttrsToList (name: _pack: ''
+      ${lib.escapeShellArg name})
+        cat ${projectPackManifests.${name}}
+        ;;
+    '')
+    piSkills.projectPacks);
+
+  piPack = pkgs.writeShellApplication {
+    name = "pi-pack";
+    runtimeInputs = [pkgs.coreutils];
+    text = ''
+      usage() {
+        cat <<'USAGE'
+      usage:
+        pi-pack list
+        pi-pack show <pack>
+        pi-pack install <pack> [project-dir]
+      USAGE
+      }
+
+      link_entry() {
+        dest="$1"
+        src="$2"
+
+        if [ -e "$dest" ] || [ -L "$dest" ]; then
+          if [ ! -L "$dest" ]; then
+            echo "refusing to replace existing non-symlink: $dest" >&2
+            exit 1
+          fi
+        fi
+
+        ln -sfnT "$src" "$dest"
+      }
+
+      command="''${1:-list}"
+      case "$command" in
+        list)
+          cat <<'PACKS'
+      ${projectPackList}
+      PACKS
+          ;;
+
+        show)
+          pack="''${2:-}"
+          if [ -z "$pack" ]; then
+            usage >&2
+            exit 2
+          fi
+
+          case "$pack" in
+      ${projectPackShowCases}
+            *)
+              echo "unknown Pi pack: $pack" >&2
+              exit 2
+              ;;
+          esac
+          ;;
+
+        install)
+          pack="''${2:-}"
+          if [ -z "$pack" ]; then
+            usage >&2
+            exit 2
+          fi
+
+          target="''${3:-$PWD}"
+          target="$(cd "$target" && pwd -P)"
+
+          case "$pack" in
+      ${projectPackInstallCases}
+            *)
+              echo "unknown Pi pack: $pack" >&2
+              exit 2
+              ;;
+          esac
+          ;;
+
+        help|--help|-h)
+          usage
+          ;;
+
+        *)
+          usage >&2
+          exit 2
+          ;;
+      esac
+    '';
+  };
+
   piSettings = {
     defaultProvider = "openai-codex";
     defaultModel = "gpt-5.5";
@@ -49,17 +164,9 @@
 
     enableSkillCommands = true;
 
-    packages =
-      [
-        "npm:pi-subagents"
-        "npm:@vanillagreen/pi-skills-manager"
-        "npm:@vanillagreen/pi-web-tools"
-        "npm:pi-lean-ctx"
-        "npm:@victor-software-house/pi-curated-themes"
-      ]
-      ++ piSkills.packages;
+    packages = piSkills.packages;
 
-    skills = (skillPaths piSkills.startupSkillNames) ++ piSkills.repositorySkillPaths;
+    skills = defaultSkills;
 
     theme = "catppuccin-mocha";
   };
@@ -71,15 +178,18 @@ in {
     piSkillsInstall
     piSkillsUpdate
     piSkillsCheck
+    piPack
   ];
   home.file.".pi/agent/settings.json".text = builtins.toJSON piSettings;
 
   programs.zsh.shellAliases = {
     # Exact profile launchers: no implicit skill discovery; only the listed
     # installed/updateable skills are loaded.
-    pi-code = "${pi} --no-skills ${skillFlags (skillPaths piSkills.codingSkillNames)}";
-    pi-data = "${pi} --no-skills ${skillFlags (skillPaths piSkills.dataEngSkillNames)}";
-    pi-aws = "${pi} --no-skills ${skillFlags (skillPaths piSkills.awsSkillNames)}";
+    pi-code = "${pi} --no-skills ${skillFlags (profileSkills "code")}";
+    pi-data = "${pi} --no-skills ${skillFlags (profileSkills "data")}";
+    pi-aws = "${pi} --no-skills ${skillFlags (profileSkills "aws")}";
+    pi-logfire = "${pi} --no-skills ${skillFlags (profileSkills "logfire")}";
+    pi-pydantic = "${pi} --no-skills ${skillFlags (profileSkills "pydantic")}";
 
     # Keep previous names as aliases.
     pi-code-clean = "pi-code";

--- a/programs/skills.nix
+++ b/programs/skills.nix
@@ -1,4 +1,7 @@
-{skillSources}: let
+{
+  lib,
+  skillSources,
+}: let
   awsSkillNames = [
     # Core
     "amazon-bedrock"
@@ -66,6 +69,20 @@
     "yeet"
   ];
 
+  pydanticSkillNames = [
+    "building-pydantic-ai-agents"
+    "logfire-instrumentation"
+    "logfire-query"
+    "logfire-ui"
+    "pydantic-ai-harness"
+  ];
+
+  logfireSkillNames = [
+    "logfire-instrumentation"
+    "logfire-query"
+    "logfire-ui"
+  ];
+
   otherSkillPackages = [
     {
       name = "github-code-review";
@@ -87,8 +104,34 @@
       source = "${repo}@${name}";
     })
     names;
+
+  sourceSkillPath = source: name: "${source}/skills/${name}";
+  sourcePluginPath = source: name: "${source}/plugins/${name}";
+
+  namedPaths = pathFor: names:
+    map (name: {
+      inherit name;
+      path = pathFor name;
+    })
+    names;
+
+  pathEntry = name: path: {inherit name path;};
+  pluginSkillsPath = source: name: "${source}/plugins/${name}/skills";
+  pydanticSkillPaths = namedPaths (sourceSkillPath skillSources.pydantic-skills) pydanticSkillNames;
+  logfireSkillPaths = namedPaths (sourceSkillPath skillSources.pydantic-skills) logfireSkillNames;
 in rec {
-  packages = [];
+  packagePacks = {
+    core = [
+      "npm:pi-subagents"
+      "npm:@vanillagreen/pi-skills-manager"
+      "npm:@vanillagreen/pi-web-tools"
+      "npm:pi-lean-ctx"
+      "npm:@victor-software-house/pi-curated-themes"
+    ];
+  };
+
+  defaultPackagePackNames = ["core"];
+  packages = lib.unique (lib.concatLists (map (name: packagePacks.${name}) defaultPackagePackNames));
 
   repositorySkillPaths = [
     "${skillSources.openai-skills}/skills/.curated"
@@ -105,41 +148,151 @@ in rec {
     ++ skillPackagesFor "aws/agent-toolkit-for-aws" awsSkillNames
     ++ skillPackagesFor "duckdb/duckdb-skills" duckdbSkillNames;
 
-  startupSkillNames = [
-    "yeet"
-    "github-code-review"
-    "agent-pr-manager"
-  ];
+  skillPacks = {
+    startup = {
+      description = "Default mutable skills loaded by normal Pi sessions.";
+      skillNames = [
+        "yeet"
+        "github-code-review"
+        "agent-pr-manager"
+      ];
+      skillPaths = [];
+    };
 
-  codingSkillNames = [
-    "aws-iam"
-    "aws-cdk"
-    "aws-cloudformation"
-    "aws-serverless"
-    "aws-sdk-python-usage"
-    "connecting-lambda-to-api-gateway"
-    "connecting-lambda-to-dynamodb"
-    "debugging-lambda-timeouts"
-    "creating-api-gateway-stage"
-    "lsp-setup"
-  ];
+    repositories = {
+      description = "Pinned Nix skill source trees exposed for Pi skill discovery.";
+      skillNames = [];
+      skillPaths = repositorySkillPaths;
+    };
 
-  dataEngSkillNames =
-    duckdbSkillNames
-    ++ [
-      "aws-iam"
-      "connecting-to-data-source"
-      "exploring-data-catalog"
-      "finding-data-lake-assets"
-      "ingesting-into-data-lake"
-      "querying-data-lake"
-      "creating-data-lake-table"
-      "creating-amazon-aurora-db-cluster-with-instances"
-      "exporting-rds-to-s3"
-      "securing-s3-buckets"
-      "storing-and-querying-vectors"
-      "troubleshooting-s3-files"
-    ];
+    coding = {
+      description = "AWS and LSP skills for software projects.";
+      skillNames = [
+        "aws-iam"
+        "aws-cdk"
+        "aws-cloudformation"
+        "aws-serverless"
+        "aws-sdk-python-usage"
+        "connecting-lambda-to-api-gateway"
+        "connecting-lambda-to-dynamodb"
+        "debugging-lambda-timeouts"
+        "creating-api-gateway-stage"
+        "lsp-setup"
+      ];
+      skillPaths = [];
+    };
 
-  inherit awsSkillNames duckdbSkillNames openaiSkillNames;
+    aws = {
+      description = "All managed AWS Agent Toolkit skills.";
+      skillNames = awsSkillNames;
+      skillPaths = [];
+    };
+
+    data-eng = {
+      description = "DuckDB, data lake, and database-oriented skills.";
+      skillNames =
+        duckdbSkillNames
+        ++ [
+          "aws-iam"
+          "connecting-to-data-source"
+          "exploring-data-catalog"
+          "finding-data-lake-assets"
+          "ingesting-into-data-lake"
+          "querying-data-lake"
+          "creating-data-lake-table"
+          "creating-amazon-aurora-db-cluster-with-instances"
+          "exporting-rds-to-s3"
+          "securing-s3-buckets"
+          "storing-and-querying-vectors"
+          "troubleshooting-s3-files"
+        ];
+      skillPaths = [];
+    };
+
+    logfire = {
+      description = "Pinned Pydantic Logfire skills.";
+      skillNames = [];
+      skillPaths = map (skill: skill.path) logfireSkillPaths;
+    };
+
+    pydantic = {
+      description = "All pinned Pydantic skills.";
+      skillNames = [];
+      skillPaths = map (skill: skill.path) pydanticSkillPaths;
+    };
+  };
+
+  defaultSkillPackNames = ["startup" "repositories"];
+
+  profilePackNames = {
+    code = ["startup" "coding"];
+    data = ["startup" "data-eng"];
+    aws = ["startup" "aws"];
+    logfire = ["startup" "logfire"];
+    pydantic = ["startup" "pydantic"];
+  };
+
+  projectPacks = {
+    aws = {
+      description = "Project-local AWS Agent Toolkit skills and plugins.";
+      skills = [
+        (pathEntry "aws" "${skillSources.aws-agent-toolkit-for-aws}/skills")
+      ];
+      plugins = namedPaths (sourcePluginPath skillSources.aws-agent-toolkit-for-aws) [
+        "aws-core"
+        "aws-agents"
+        "aws-data-analytics"
+      ];
+    };
+
+    aws-core = {
+      description = "Project-local AWS Core skills and plugin.";
+      skills = [
+        (pathEntry "aws-core" (pluginSkillsPath skillSources.aws-agent-toolkit-for-aws "aws-core"))
+      ];
+      plugins = namedPaths (sourcePluginPath skillSources.aws-agent-toolkit-for-aws) ["aws-core"];
+    };
+
+    aws-agents = {
+      description = "Project-local AWS agent-building skills and plugin.";
+      skills = [
+        (pathEntry "aws-agents" (pluginSkillsPath skillSources.aws-agent-toolkit-for-aws "aws-agents"))
+      ];
+      plugins = namedPaths (sourcePluginPath skillSources.aws-agent-toolkit-for-aws) ["aws-agents"];
+    };
+
+    aws-data-analytics = {
+      description = "Project-local AWS data analytics skills and plugin.";
+      skills = [
+        (pathEntry "aws-data-analytics" (pluginSkillsPath skillSources.aws-agent-toolkit-for-aws "aws-data-analytics"))
+      ];
+      plugins = namedPaths (sourcePluginPath skillSources.aws-agent-toolkit-for-aws) ["aws-data-analytics"];
+    };
+
+    logfire = {
+      description = "Project-local Logfire skills plus Logfire Codex/Pi plugins.";
+      skills = [
+        (pathEntry "logfire" (pluginSkillsPath skillSources.pydantic-skills "logfire"))
+      ];
+      plugins = namedPaths (sourcePluginPath skillSources.pydantic-skills) [
+        "logfire"
+        "logfire-exporter"
+      ];
+    };
+
+    pydantic = {
+      description = "Project-local Pydantic AI and Logfire skills/plugins.";
+      skills = [
+        (pathEntry "pydantic" "${skillSources.pydantic-skills}/skills")
+      ];
+      plugins = namedPaths (sourcePluginPath skillSources.pydantic-skills) [
+        "ai"
+        "logfire"
+        "logfire-exporter"
+        "pydantic-ai-harness"
+      ];
+    };
+  };
+
+  inherit awsSkillNames duckdbSkillNames openaiSkillNames pydanticSkillNames logfireSkillNames;
 }


### PR DESCRIPTION
## Summary
- centralize Pi packages, skill profiles, and project packs in programs/skills.nix
- derive Pi settings, exact profile aliases, and the pi-pack helper from that catalog
- add project-installable packs for AWS, AWS sub-bundles, Logfire, and Pydantic via pinned Nix source folders

## Validation
- nix fmt programs/skills.nix
- nix build .#homeConfigurations.mebaran.activationPackage
- pi-pack list
- pi-pack install aws /tmp/...
- pi-pack install aws-core /tmp/...